### PR TITLE
axio config: support non-HTTPS cookies

### DIFF
--- a/axio-lib/private/axio-config.rkt
+++ b/axio-lib/private/axio-config.rkt
@@ -16,7 +16,7 @@
          (struct-out axio-db-config)
          (struct-out axio-smtp-config))
 
-(struct axio-config (app-secret port-base params) #:transparent)
+(struct axio-config (app-secret port-base params is-https?) #:transparent)
 
 (struct axio-db-config (server username password database) #:transparent)
 

--- a/axio-lib/private/axio-init.rkt
+++ b/axio-lib/private/axio-init.rkt
@@ -23,11 +23,12 @@
 (define (axio-init config
                    #:db-config   [ db-config #f ]
                    #:smtp-config [ smtp-config #f ]
+                   ;; TODO: this not exposed by axio-app-init
                    #:log-level   [ log-level 'warning ])
   (axio-init-config config
                     #:db-config db-config
                     #:smtp-config smtp-config)
-                    
+
   (axio-init-logger log-level)
 
   (build-axio-context (axio-init-db)))

--- a/axio-lib/private/axio-session.rkt
+++ b/axio-lib/private/axio-session.rkt
@@ -46,11 +46,12 @@
   (hash-remove session 'flash))
 
 (define (create-session-cookie session)
+  (define config (get-axio-config))
   (make-id-cookie "session"
                   (serialize-session session)
-                  #:key (axio-config-app-secret (get-axio-config))
+                  #:key (axio-config-app-secret config)
                   #:path "/"
-                  #:secure? #t  ; requires https
+                  #:secure? (axio-config-is-https? config)
                   #:max-age (+ thirty-days-seconds (seconds-until-midnight))
                   #:http-only? #t))
 


### PR DESCRIPTION
Presumably this configuration bit could be used by other components where necessary, but the central use of axio's is-https? right now is in create-session-cookie where it is passed to make-id-cookie: the previous defaults turn out to work in Chrome over HTTP but not Safari (versions may matter).

This configuration provides a hook for developers to request HTTP during local development of an axio app but for the deployed application to use HTTPS (the default).

Also note a TODO: log-level is not currently exposed by axio-app-init, which may be an oversight. This means log-level is not currently configurable in the normal way (though you could probably still glue the pieces together yourself).