### PR TITLE
Support query params (and other misc. syntax clean up)

### DIFF
--- a/axio-lib/private/axio-syntax.rkt
+++ b/axio-lib/private/axio-syntax.rkt
@@ -31,7 +31,7 @@
 
 (define-syntax (generate-router stx)
   (syntax-parse stx
-    [(_ route-fun do-route not-found-func (path:string func pred?) ...)
+    [(_ route-fun:id do-route:expr not-found-func:expr (path:string func:expr pred?:expr) ...)
      (define paths (map syntax-e (syntax->list #'(path ...))))
      (define splits (for/list ([ path paths ])
                       (string-split path "/")))
@@ -45,7 +45,7 @@
 
 (define-syntax (generate-url-for stx)
   (syntax-parse stx
-    [(_ url-for-fun (path route-name) ...)
+    [(_ url-for-fun:id (path:string route-name) ...)
      #'(begin
          (define hsh (make-immutable-hash '((route-name . path) ...)))
 
@@ -58,16 +58,17 @@
 
 (define-syntax (routes stx)
   (syntax-parse stx
-    [(r (~optional (~seq #:url-fun url-for-fun:id)
+    [(_ (~optional (~seq #:url-fun url-for-fun:id)
                    #:defaults ([url-for-fun (format-id #'r "axio-url-for")]))
-        (path func
-              (~optional (~seq #:name route-name:id)
-                         #:defaults ([route-name #'#f]))
-              (~optional (~seq #:when pred?:id)
-                         #:defaults ([pred? #'(const #t)]))
-              #;(~optional (~seq #:methods method-lst:expr)
-                           #:defaults ([method-lst #''()]))) ...
-        not-found-func)
+        (path:string
+         func:expr
+         (~optional (~seq #:name route-name:id)
+                    #:defaults ([route-name #'#f]))
+         (~optional (~seq #:when pred?:expr)
+                    #:defaults ([pred? #'(const #t)]))
+         #;(~optional (~seq #:methods method-lst:expr)
+                      #:defaults ([method-lst #''()]))) ...
+        not-found-func:expr)
      #:with route-fun (format-id #'r "axio-route")
      #'(begin
          (provide route-fun url-for-fun)

--- a/axio-lib/private/axio-syntax.rkt
+++ b/axio-lib/private/axio-syntax.rkt
@@ -31,7 +31,7 @@
 
 (define-syntax (generate-router stx)
   (syntax-parse stx
-    [(_ route-fun:id do-route:expr not-found-func:expr (path:string func:expr pred?:expr) ...)
+    [(_ route-fun:id not-found-func:expr (path:string func:expr pred?:expr) ...)
      (define paths (map syntax-e (syntax->list #'(path ...))))
      (define splits (for/list ([ path paths ])
                       (string-split path "/")))
@@ -40,7 +40,7 @@
            (let-values ([ (web-request method path-nodes) (axio-parse-ctx-path ctx) ])
              (cond
                [ (axio-match-path-to-route web-request path-nodes (quote route-nodes) pred?)
-                 => (λ (path-attrs) (do-route func ctx path-attrs)) ] ...
+                 => (λ (path-attrs) (axio-do-route func ctx path-attrs)) ] ...
                [ else (not-found-func ctx) ]))))]))
 
 (define-syntax (generate-url-for stx)
@@ -71,6 +71,6 @@
      #:with route-fun (format-id #'r "axio-route")
      #'(begin
          (provide route-fun url-for-fun)
-         (generate-router route-fun axio-do-route not-found-func (path func pred?) ...)
+         (generate-router route-fun not-found-func (path func pred?) ...)
          (generate-url-for url-for-fun (path (~? route-name)) ...))]))
 

--- a/axio-lib/private/axio-syntax.rkt
+++ b/axio-lib/private/axio-syntax.rkt
@@ -45,9 +45,9 @@
 
 (define-syntax (generate-url-for stx)
   (syntax-parse stx
-    [(_ url-for-fun:id (path:string route-name) ...)
+    [(_ url-for-fun:id (path:string (~optional route-name:id)) ...)
      #'(begin
-         (define hsh (make-immutable-hash '((route-name . path) ...)))
+         (define hsh (make-immutable-hash '((~? (route-name . path)) ...)))
 
          (define/contract (url-for-fun a-route-name [ arg (hash) ] #:query [ query-params '() ])
            (->* (symbol?)
@@ -62,8 +62,7 @@
                    #:defaults ([url-for-fun (format-id #'r "axio-url-for")]))
         (path:string
          func:expr
-         (~optional (~seq #:name route-name:id)
-                    #:defaults ([route-name #'#f]))
+         (~optional (~seq #:name route-name:id))
          (~optional (~seq #:when pred?:expr)
                     #:defaults ([pred? #'(const #t)]))
          #;(~optional (~seq #:methods method-lst:expr)
@@ -73,5 +72,5 @@
      #'(begin
          (provide route-fun url-for-fun)
          (generate-router route-fun axio-do-route not-found-func (path func pred?) ...)
-         (generate-url-for url-for-fun (path route-name) ...))]))
+         (generate-url-for url-for-fun (path (~? route-name)) ...))]))
 


### PR DESCRIPTION
The major point is the `#:query` support; the rest is incidental.

In particular, you may want to drop 8d2bad4 (syntax: remove generate-router's do-route, 2024-05-31) if you want to keep `generate-router`'s ability to take an arbitrary `do-route`. I didn't see a great need for it, though.